### PR TITLE
remove erroneous directory path from run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ MAPBOX_TOKEN=abcdefg
 ## Run
 
 ```sh
-cd bayes-mvp/client
 yarn
 yarn build
 yarn start


### PR DESCRIPTION
Looks like this is a holdover from the old repo - you actually just need to run Yarn from the root of the repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/tds-frontend/29)
<!-- Reviewable:end -->
