### PR TITLE
use cdn (fix #25)

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,7 +1,7 @@
 import { identity } from 'lodash'
 import Arrow from 'material-ui/svg-icons/navigation/arrow-drop-down'
 import * as React from 'react'
-import ReactAutocomplete = require('react-autocomplete')
+import * as ReactAutocomplete from 'react-autocomplete'
 import './Autocomplete.css'
 
 type Props = {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,8 +4,15 @@
   <meta charset="utf-8">
   <title><%= htmlWebpackPlugin.options.title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.css" rel='stylesheet' />
 </head>
 <body>
   <div id="App"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.4/lodash.min.js"></script>
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.js"></script>
+  <script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/5.5.2/Rx.min.js"></script>
 </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "dom",
       "es2017"
     ],
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "newLine": "LF",
     "outDir": "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,14 @@ module.exports = {
     port: 8081
   },
   entry: './src/index.tsx',
+  externals: {
+    'chart.js': 'Chart',
+    lodash: '_',
+    mapboxgl: 'mapboxgl',
+    rx: 'Rx',
+    react: 'React',
+    'react-dom': 'ReactDOM'
+  },
   output: {
     filename: 'bundle.js',
     path: __dirname + '/dist'


### PR DESCRIPTION
A few notes:

- The upside of CDNing is even without using HTTP2, assets can load in parallel so 1st page loads are faster
- The downside is you now need internet access to run the frontend locally (we could also look into using node_modules locally and CDN for prod builds)
- We still need to CDN Material-UI (which accounts for the majority of our bundle's size), but a CDN'd version doesn't seem to exist (?!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/tds-frontend/51)
<!-- Reviewable:end -->
