### PR TITLE
Ability to download analysis results as CSV (fix #31, fix #61)

### DIFF
--- a/src/components/AnalyticsDrawer/AnalyticsDrawer.css
+++ b/src/components/AnalyticsDrawer/AnalyticsDrawer.css
@@ -15,3 +15,20 @@
   display: block;
   text-decoration: none;
 }
+
+.LeftDrawer .DownloadAnalysisLink {
+  position: absolute !important; /* override material-ui inline style */
+    bottom: 80px;
+    right: 20px;
+}
+
+/* Don't cover up Download CSV link */
+.LeftDrawer .ServiceAreaAnalytics,
+.LeftDrawer .TotalAnalytics {
+  overflow-y: auto;
+  position: absolute;
+    bottom: 124px;
+    right: 20px;
+    left: 20px;
+    top: 95px;
+}

--- a/src/components/AnalyticsDrawer/AnalyticsDrawer.tsx
+++ b/src/components/AnalyticsDrawer/AnalyticsDrawer.tsx
@@ -1,13 +1,47 @@
 import { Drawer } from 'material-ui'
+import ProvidersIcon from 'mui-icons/cmdi/account-multiple'
 import MarkerIcon from 'mui-icons/cmdi/map-marker'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { withStore } from '../../services/store'
+import { DownloadAnalysisLink } from '../DownloadAnalysisLink/DownloadAnalysisLink'
 import { InfoBox } from '../InfoBox/InfoBox'
 import { ServiceAreaSelector } from '../ServiceAreaSelector/ServiceAreaSelector'
 import './AnalyticsDrawer.css'
 import { ServiceAreaAnalytics } from './ServiceAreaAnalytics'
 import { TotalAnalytics } from './TotalAnalytics'
+
+let Analytics = withStore(
+  'providers',
+  'selectedServiceArea',
+  'serviceAreas'
+)(({ store }) => {
+
+  if (store.get('serviceAreas').length === 0) {
+    return <InfoBox large>
+      Please choose a service area in the <Link to='/service-areas'><MarkerIcon /> Service Areas drawer</Link>
+    </InfoBox>
+  }
+
+  if (store.get('providers').length === 0) {
+    return <InfoBox large>
+      Please upload providers in the <Link to='/providers'><ProvidersIcon /> Providers drawer</Link>
+    </InfoBox>
+  }
+
+  if (store.get('selectedServiceArea')) {
+    return <div>
+      <ServiceAreaAnalytics />
+      <DownloadAnalysisLink />
+    </div>
+  }
+
+  return <div>
+    <TotalAnalytics />
+    <DownloadAnalysisLink />
+  </div>
+
+})
 
 /**
  * TODO: Show loading indicator while CSV is uploading + parsing
@@ -20,11 +54,6 @@ export let AnalyticsDrawer = withStore('representativePoints', 'selectedServiceA
       onChange={store.set('selectedServiceArea')}
       value={store.get('selectedServiceArea')}
     />
-    {store.get('serviceAreas').length > 0
-      ? (store.get('selectedServiceArea') ? <ServiceAreaAnalytics /> : <TotalAnalytics />)
-      : <InfoBox large>
-        Please choose a service area in the <Link to='/service-areas'><MarkerIcon /> Service Areas drawer</Link>
-      </InfoBox>
-    }
+    <Analytics />
   </Drawer>
 )

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -70,9 +70,17 @@ p {
 
 /*
   Material-UI Augmentations
+
+  Inline styles are the worst..
 */
 
-/* inline styles are the worst.. */
+.Button.-Primary {
+  color: var(--primary) !important;
+}
+.Button.-Primary path {
+  fill: var(--primary) !important;
+}
+
 .DropDownMenu.-Compact button + div {
   display: none !important;
 }

--- a/src/components/DownloadAnalysisLink/DownloadAnalysisLink.css
+++ b/src/components/DownloadAnalysisLink/DownloadAnalysisLink.css
@@ -1,0 +1,5 @@
+@import "../../index.css";
+
+.DownloadAnalysisLink {
+  color: var(--primary-dark);
+}

--- a/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
+++ b/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
@@ -22,16 +22,17 @@ function onClick(store: Store) {
   return () => {
     let headers = [
       'CountyName',
-      // 'City', // TODO
       'ZipCode',
       'SpecDesc',
+      'BeneficiariesWithAccess',
       'BeneficiariesWithoutAccess',
+      'PctWithAccess',
       'PctWithoutAccess',
       'MinDist (mi)',
-      'MinTime (min)',
       'AvgDist (mi)',
-      'AvgTime (min)',
       'MaxDist (mi)',
+      'MinTime (min)',
+      'AvgTime (min)',
       'MaxTime (min)'
     ]
     let selectedServiceArea = store.get('selectedServiceArea')
@@ -41,18 +42,25 @@ function onClick(store: Store) {
     let data = serviceAreas.map(_ => {
       let representativePoint = representativePointsFromServiceAreas([_], store).value()[0]
       let adequacies = adequaciesFromServiceArea(_, store)
-      let { numInadequatePopulation, percentInadequatePopulation } = summaryStatistics([_], store)
+      let {
+        numAdequatePopulation,
+        numInadequatePopulation,
+        percentAdequatePopulation,
+        percentInadequatePopulation
+      } = summaryStatistics([_], store)
       return [
         representativePoint.county,
         representativePoint.zip,
         store.get('providers')[0].specialty, // TODO: Is this safe to assume?
+        numAdequatePopulation,
         numInadequatePopulation,
+        percentAdequatePopulation,
         percentInadequatePopulation,
         minDistance(adequacies),
-        minTime(adequacies),
         averageDistance(adequacies),
-        averageTime(adequacies),
         maxDistance(adequacies),
+        minTime(adequacies),
+        averageTime(adequacies),
         maxTime(adequacies)
       ]
     })

--- a/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
+++ b/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
@@ -1,0 +1,62 @@
+import { FlatButton } from 'material-ui'
+import DownloadIcon from 'material-ui/svg-icons/file/file-download'
+import * as React from 'react'
+import { Store, withStore } from '../../services/store'
+import { averageDistance, averageTime, maxDistance, maxTime, minDistance, minTime } from '../../utils/analytics'
+import { generateCSV } from '../../utils/csv'
+import { adequaciesFromServiceArea, representativePointsFromServiceAreas, summaryStatistics } from '../../utils/data'
+import { download } from '../../utils/download'
+import './DownloadAnalysisLink.css'
+
+export let DownloadAnalysisLink = withStore()(({ store }) =>
+  <FlatButton
+    className='DownloadAnalysisLink Button -Primary'
+    icon={<DownloadIcon />}
+    label='Download'
+    labelPosition='before'
+    onClick={onClick(store)}
+  />
+)
+
+function onClick(store: Store) {
+  return () => {
+    let headers = [
+      'CountyName',
+      // 'City', // TODO
+      'ZipCode',
+      'SpecDesc',
+      'BeneficiariesWithoutAccess',
+      'PctWithoutAccess',
+      'MinDist (mi)',
+      'MinTime (min)',
+      'AvgDist (mi)',
+      'AvgTime (min)',
+      'MaxDist (mi)',
+      'MaxTime (min)'
+    ]
+    let selectedServiceArea = store.get('selectedServiceArea')
+    let serviceAreas = selectedServiceArea
+      ? [selectedServiceArea]
+      : store.get('serviceAreas')
+    let data = serviceAreas.map(_ => {
+      let representativePoint = representativePointsFromServiceAreas([_], store).value()[0]
+      let adequacies = adequaciesFromServiceArea(_, store)
+      let { numInadequatePopulation, percentInadequatePopulation } = summaryStatistics([_], store)
+      return [
+        representativePoint.county,
+        representativePoint.zip,
+        store.get('providers')[0].specialty, // TODO: Is this safe to assume?
+        numInadequatePopulation,
+        percentInadequatePopulation,
+        minDistance(adequacies),
+        minTime(adequacies),
+        averageDistance(adequacies),
+        averageTime(adequacies),
+        maxDistance(adequacies),
+        maxTime(adequacies)
+      ]
+    })
+    let csv = generateCSV(headers, data)
+    download(csv, 'text/csv', `bayesimpact-analysis-${new Date().toISOString()}.csv`)
+  }
+}

--- a/src/components/ServiceAreaSelector/ServiceAreaSelector.tsx
+++ b/src/components/ServiceAreaSelector/ServiceAreaSelector.tsx
@@ -10,13 +10,12 @@ type Props = StoreProps & {
 
 const ALL_SERVICE_AREAS = 'All service areas'
 
-export let ServiceAreaSelector = withStore('serviceAreas')<Props>(({ onChange, store, value }) => {
-  console.log('ServiceAreaSelector', value)
-  return <Autocomplete
+export let ServiceAreaSelector = withStore('serviceAreas')<Props>(({ onChange, store, value }) =>
+  <Autocomplete
     defaultValue={ALL_SERVICE_AREAS}
     items={store.get('serviceAreas').map(formatServiceArea)}
     onChange={_ => onChange(_ === ALL_SERVICE_AREAS ? null : unformatServiceArea(_))}
     pinnedItems={[ALL_SERVICE_AREAS]}
     value={value === null ? ALL_SERVICE_AREAS : formatServiceArea(value)}
   />
-})
+)

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,5 +1,5 @@
 import { chain } from 'lodash'
-import { parse as papaparse } from 'papaparse'
+import { parse as papaparse, unparse } from 'papaparse'
 
 export function parseCSV<T>(csvFile: File): Promise<T[]> {
   return new Promise((resolve, reject) =>
@@ -109,6 +109,10 @@ function readRow(csvRow: string[], columnIndices: number[]) {
     }
     return csvRow[index]
   })
+}
+
+export function generateCSV(headers: string[], data: (string | number)[][]) {
+  return unparse({ fields: headers, data })
 }
 
 export class ParseError {

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,22 @@
+/**
+ * Download a file that was generated on the client.
+ *
+ * @see https://github.com/mholt/PapaParse/issues/175#issuecomment-201308792
+ *
+ * TODO: Move this to its own module.
+ */
+export function download(contents: string, mimeType: string, filename: string) {
+  let csvData = new Blob([contents], { type: `${mimeType};charset=utf-8;` })
+  if (navigator.msSaveBlob) {
+    // IE11 & Edge
+    navigator.msSaveBlob(csvData, filename)
+  } else {
+    // In FF link must be added to DOM to be clicked
+    let link = document.createElement('a')
+    link.href = window.URL.createObjectURL(csvData)
+    link.setAttribute('download', filename)
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -11,6 +11,9 @@ export function formatNumber(n: number) {
     case -Infinity:
       return '-'
     default:
+      if (Number.isNaN(n)) {
+        return '-'
+      }
       return n.toLocaleString()
   }
 }


### PR DESCRIPTION
<img width="1680" alt="screen shot 2017-11-22 at 8 35 24 pm" src="https://user-images.githubusercontent.com/1761758/33159089-b15e5f7c-cfc4-11e7-8314-e402410bc4cf.png">

Sample CSVs (converted to XLS for github):

- 1 Service Area (selection): [bayesimpact-analysis-2017-11-23T04_30_07.xlsx](https://github.com/bayesimpact/tds-frontend/files/1498023/bayesimpact-analysis-2017-11-23T04_30_07.xlsx)
- A bunch of service areas: [bayesimpact-analysis-2017-11-23T04_27_07.xlsx](https://github.com/bayesimpact/tds-frontend/files/1498024/bayesimpact-analysis-2017-11-23T04_27_07.xlsx)

@viviandien @ericboucher @tetraptych Open questions:

1. When population is `0`, we can't compute some statistics (like % without access, number without access). Can we fix this in the DB? For now, I am explicitly surfacing the error in CSVs (see `NaN`s in the 2nd XLSX above), and showing it as `-` in the UI so it doesn't look like an error, but like missing data.
2. Quest gives the users City as well. Do we have this data? How can we get it to the frontend?