### PR TITLE
Add lazy-apps true for EOF bug closes  #136

### DIFF
--- a/backend/config/uwsgi.ini
+++ b/backend/config/uwsgi.ini
@@ -4,3 +4,4 @@ callable = app
 buffer-size = 65535
 catch-exceptions = true
 enable-threads = true
+lazy-apps = true


### PR DESCRIPTION
Attempts to solve https://github.com/bayesimpact/tds/issues/136 based on https://www.bountysource.com/issues/9396331-operationalerror-when-using-reflect-with-uwsgi-and-multiple-processes

Since we can't reproduce consistently, we can close the issue with this resolution, then reopen if it comes up again   