### PR TITLE
Use ALBs in configuration over NLBs; fixes #264

### DIFF
--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -4,6 +4,7 @@ provider "aws" {
 
 locals {
   security_group_name = "${var.app_security_group_name}-${var.env_name}"
+  load_balancer_name = "${var.load_balancer_name}-${var.env_name}"
 }
 
 # This is the ec2 instance representing the default app server.
@@ -94,5 +95,23 @@ resource "aws_security_group" "na_app_sg" {
 
   tags {
     Name = "na_app_sg"
+  }
+}
+
+# Application load balancer for appserver[s]
+resource "aws_lb" "na_app_elb" {
+  name                       = "${local.load_balancer_name}"
+  internal                   = false
+  ip_address_type            = "ipv4"
+  load_balancer_type         = "application"
+  enable_deletion_protection = true
+  idle_timeout               = 60
+  security_groups = ["${aws_security_group.na_app_sg.id}"]
+
+  subnets = ["${aws_instance.na_app.subnet_id}"]
+
+  tags {
+    Environment = "${var.env_name}"
+    Name = "${local.load_balancer_name}"
   }
 }

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -7,6 +7,12 @@ locals {
   load_balancer_name = "${var.load_balancer_name}-${var.env_name}"
 }
 
+# Bayes Impact Default VPC.
+resource "aws_vpc" "main" {
+  cidr_block       = "172.31.0.0/16"
+  instance_tenancy = "default"
+}
+
 # This is the ec2 instance representing the default app server.
 resource "aws_instance" "na_app" {
   # These two attributes are required.
@@ -106,7 +112,7 @@ resource "aws_lb" "na_app_elb" {
   load_balancer_type         = "application"
   enable_deletion_protection = true
   idle_timeout               = 60
-  security_groups = ["${aws_security_group.na_app_sg.id}"]
+  security_groups            = ["${aws_security_group.na_app_sg.id}"]
 
   subnets = ["${aws_instance.na_app.subnet_id}"]
 
@@ -114,4 +120,46 @@ resource "aws_lb" "na_app_elb" {
     Environment = "${var.env_name}"
     Name = "${local.load_balancer_name}"
   }
+}
+
+resource "aws_lb_target_group" "na_lb_tg_80" {
+  name        = "na-app-tg-80-${var.env_name}"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = "${aws_vpc.main.id}"
+  target_type = "instance"
+}
+
+resource "aws_lb_target_group_attachment" "na_lb_tga_80" {
+  target_group_arn = "${aws_lb_target_group.na_lb_tg_80.arn}"
+  target_id        = "${aws_instance.na_app.id}"
+  port             = 80
+}
+
+resource "aws_lb_target_group" "na_lb_tg_8080" {
+  name        = "na-app-tg-8080-${var.env_name}"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = "${aws_vpc.main.id}"
+  target_type = "instance"
+}
+
+resource "aws_lb_target_group_attachment" "na_lb_tga_8080" {
+  target_group_arn = "${aws_lb_target_group.na_lb_tg_8080.arn}"
+  target_id        = "${aws_instance.na_app.id}"
+  port             = 8080
+}
+
+resource "aws_lb_target_group" "na_lb_tg_8081" {
+  name        = "na-app-tg-8081-${var.env_name}"
+  port        = 8081
+  protocol    = "HTTP"
+  vpc_id      = "${aws_vpc.main.id}"
+  target_type = "instance"
+}
+
+resource "aws_lb_target_group_attachment" "na_lb_tga_8081" {
+  target_group_arn = "${aws_lb_target_group.na_lb_tg_8081.arn}"
+  target_id        = "${aws_instance.na_app.id}"
+  port             = 8081
 }

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -114,7 +114,7 @@ resource "aws_lb" "na_app_elb" {
   idle_timeout               = 60
   security_groups            = ["${aws_security_group.na_app_sg.id}"]
 
-  subnets = ["${aws_instance.na_app.subnet_id}"]
+  subnets = ["${aws_instance.na_app.subnet_id}", "subnet-825462c4", "subnet-33798e56"] # FIXME
 
   tags {
     Environment = "${var.env_name}"
@@ -136,6 +136,17 @@ resource "aws_lb_target_group_attachment" "na_lb_tga_80" {
   port             = 80
 }
 
+resource "aws_lb_listener" "na_app_elb_listener_80" {
+  load_balancer_arn = "${aws_lb.na_app_elb.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.na_lb_tg_80.arn}"
+    type             = "forward"
+  }
+}
+
 resource "aws_lb_target_group" "na_lb_tg_8080" {
   name        = "na-app-tg-8080-${var.env_name}"
   port        = 8080
@@ -150,6 +161,17 @@ resource "aws_lb_target_group_attachment" "na_lb_tga_8080" {
   port             = 8080
 }
 
+resource "aws_lb_listener" "na_app_elb_listener_8080" {
+  load_balancer_arn = "${aws_lb.na_app_elb.arn}"
+  port              = "8080"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.na_lb_tg_8080.arn}"
+    type             = "forward"
+  }
+}
+
 resource "aws_lb_target_group" "na_lb_tg_8081" {
   name        = "na-app-tg-8081-${var.env_name}"
   port        = 8081
@@ -162,4 +184,15 @@ resource "aws_lb_target_group_attachment" "na_lb_tga_8081" {
   target_group_arn = "${aws_lb_target_group.na_lb_tg_8081.arn}"
   target_id        = "${aws_instance.na_app.id}"
   port             = 8081
+}
+
+resource "aws_lb_listener" "na_app_elb_listener_8081" {
+  load_balancer_arn = "${aws_lb.na_app_elb.arn}"
+  port              = "8081"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.na_lb_tg_8081.arn}"
+    type             = "forward"
+  }
 }

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -9,7 +9,7 @@ locals {
 
 # Bayes Impact Default VPC.
 resource "aws_vpc" "main" {
-  cidr_block       = "172.31.0.0/16"
+  cidr_block       = "${var.default_vpc_cidr_block}"
   instance_tenancy = "default"
 }
 
@@ -114,7 +114,7 @@ resource "aws_lb" "na_app_elb" {
   idle_timeout               = 60
   security_groups            = ["${aws_security_group.na_app_sg.id}"]
 
-  subnets = ["${aws_instance.na_app.subnet_id}", "subnet-825462c4", "subnet-33798e56"] # FIXME
+  subnets = "${var.default_subnets}"
 
   tags {
     Environment = "${var.env_name}"

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -32,6 +32,18 @@ variable "load_balancer_name" {
   default     = "na-app-alb"
 }
 
+variable "default_subnets" {
+  description = "Default subnets in us-west-1 for Bayes Impact default VPC"
+  type        = "list"
+  default     = ["subnet-825462c4", "subnet-33798e56"]
+}
+
+variable "default_vpc_cidr_block" {
+  description = "CIDR block for default us-west-1 Bayes Impact VPC"
+  type        = "string"
+  default     = "172.31.0.0/16"
+}
+
 variable "db_password" {
   description = "The password to use for TDS DB access"
   type        = "string"

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -25,7 +25,13 @@ variable "app_security_group_name" {
   default     = "na_app_sg"
 }
 
-# TODO: find a nicer way to manage this.
+variable "load_balancer_name" {
+  # module.stack.aws_lb.na_app_elb: only alphanumeric characters and hyphens allowed in "name"
+  description = "The ELB name to use for app servers"
+  type        = "string"
+  default     = "na-app-alb"
+}
+
 variable "db_password" {
   description = "The password to use for TDS DB access"
   type        = "string"


### PR DESCRIPTION
Looks a bit verbose but we won't need to replicate this for different environments or anything. As best as I can tell there is a way to have an instance in a target group on multiple ports, but no way to have a listener on multiple ports, so I think we need to be explicit on these for every port.