### PR TITLE
Demo env + preparation for Oregon (fixes #265)

### DIFF
--- a/terraform/environments/demo/main.tf
+++ b/terraform/environments/demo/main.tf
@@ -1,0 +1,26 @@
+variable "db_password" {
+  description = "The password to use for TDS DB access"
+  type        = "string"
+}
+
+module "stack" {
+  source        = "../../template"
+
+  env_name = "demo"
+  db_id = "demo"
+  instance_name_tag = "demo"
+  db_password = "${var.db_password}"
+}
+
+# Backend definition can't have interpolation, so unfortunately this does need to be
+# duplicated between environment definitions.
+terraform {
+  backend "s3" {
+    bucket     = "encompass-terraform"
+    key        = "demo/terraform.tfstate"
+    region     = "us-west-2"
+
+    # ddb table to hold tfstate locks.
+    dynamodb_table = "tflock"
+  }
+}

--- a/terraform/environments/demo/main.tf
+++ b/terraform/environments/demo/main.tf
@@ -13,7 +13,8 @@ module "stack" {
 }
 
 # Backend definition can't have interpolation, so unfortunately this does need to be
-# duplicated between environment definitions.
+# duplicated between environment definitions. It also needs hardcoded values, hence
+# why we can't use the aws_region variable.
 terraform {
   backend "s3" {
     bucket     = "encompass-terraform"

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -12,11 +12,14 @@ module "stack" {
   db_password = "${var.db_password}"
 }
 
+# Backend definition can't have interpolation, so unfortunately this does need to be
+# duplicated between environment definitions. It also needs hardcoded values, hence
+# why we can't use the aws_region variable.
 terraform {
   backend "s3" {
     bucket     = "network-adequacy-terraform"
     key        = "na-testing/terraform.tfstate"
-    region     = "us-west-1"
+    region     = "us-west-2"
 
     # ddb table to hold tfstate locks.
     dynamodb_table = "tflock"

--- a/terraform/environments/qa/main.tf
+++ b/terraform/environments/qa/main.tf
@@ -13,12 +13,13 @@ module "stack" {
 }
 
 # Backend definition can't have interpolation, so unfortunately this does need to be
-# duplicated between environment definitions.
+# duplicated between environment definitions. It also needs hardcoded values, hence
+# why we can't use the aws_region variable.
 terraform {
   backend "s3" {
     bucket     = "network-adequacy-terraform"
     key        = "tds-qa/terraform.tfstate"
-    region     = "us-west-1"
+    region     = "us-west-2"
 
     # ddb table to hold tfstate locks.
     dynamodb_table = "tflock"

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-west-1"
+  region = "us-west-2"
 }
 
 locals {
@@ -21,7 +21,7 @@ resource "aws_instance" "na_app" {
 
   ebs_optimized                   = true
   associate_public_ip_address     = "true"
-  availability_zone               = "us-west-1b"
+  availability_zone               = "us-west-2b"
   key_name                        = "na-server"
   monitoring                      = false
   tenancy                         = "default"

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -56,6 +56,7 @@ resource "aws_db_instance" "na_db" {
   storage_type                        = "gp2"
   username                            = "tds"
   password                            = "${var.db_password}"
+  vpc_security_group_ids              = ["${aws_security_group.na_app_sg.id}"]
 }
 
 # Security group for app server.

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-west-2"
+  region = "${var.aws_region}"
 }
 
 locals {
@@ -21,7 +21,7 @@ resource "aws_instance" "na_app" {
 
   ebs_optimized                   = true
   associate_public_ip_address     = "true"
-  availability_zone               = "us-west-2b"
+  availability_zone               = "${var.aws_region}b"
   key_name                        = "na-server"
   monitoring                      = false
   tenancy                         = "default"

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -1,7 +1,8 @@
 variable "app_ami" {
   description = "The AMI ID to use for the application server"
   type        = "string"
-  default     = "ami-a47477c4" # TDS Base Image from 2018-1-10
+//  default     = "ami-a47477c4" # TDS Base Image from 2018-1-10
+  default     = "ami-9549f5ed" # TDS Base Image from 2018-1-10 in us-west-2
 }
 
 variable "env_name" {
@@ -33,13 +34,13 @@ variable "load_balancer_name" {
 }
 
 variable "default_subnets" {
-  description = "Default subnets in us-west-1 for Bayes Impact default VPC"
+  description = "Default subnets in us-west-2 for Bayes Impact default VPC"
   type        = "list"
-  default     = ["subnet-825462c4", "subnet-33798e56"]
+  default     = ["subnet-ac9498ea", "subnet-7a9d531f"]
 }
 
 variable "default_vpc_cidr_block" {
-  description = "CIDR block for default us-west-1 Bayes Impact VPC"
+  description = "CIDR block for default us-west-2 Bayes Impact VPC"
   type        = "string"
   default     = "172.31.0.0/16"
 }

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -48,3 +48,9 @@ variable "db_password" {
   description = "The password to use for TDS DB access"
   type        = "string"
 }
+
+variable "aws_region" {
+  description = "The region to use for the AWS provider"
+  type        = "string"
+  default     = "us-west-2" # Default to Oregon
+}

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -1,7 +1,6 @@
 variable "app_ami" {
   description = "The AMI ID to use for the application server"
   type        = "string"
-//  default     = "ami-a47477c4" # TDS Base Image from 2018-1-10
   default     = "ami-9549f5ed" # TDS Base Image from 2018-1-10 in us-west-2
 }
 


### PR DESCRIPTION
Adds demo environment which is currently live in us-west-2 region.

Only other change is adding the correct security group IDs to the DB definition so that DB instances will allow inbound communication from appservers by default.

Last thing to do is to decide on the "final" tags and names for things that we want before I reprovision everything in us-west-2.