### PR TITLE
us-west-2 migration (fixes #270)

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -3,12 +3,16 @@ variable "db_password" {
   type        = "string"
 }
 
+locals {
+  env_name = "prod"
+}
+
 module "stack" {
   source        = "../../template"
 
-  env_name = "prod"
-  db_id = "philip-testing"
-  instance_name_tag = "na-teddy"
+  env_name = "${local.env_name}"
+  db_id = "time-distance-database" # This name predates the use of terraform.
+  instance_name_tag = "encompass-${local.env_name}"
   db_password = "${var.db_password}"
 }
 
@@ -17,8 +21,8 @@ module "stack" {
 # why we can't use the aws_region variable.
 terraform {
   backend "s3" {
-    bucket     = "network-adequacy-terraform"
-    key        = "na-testing/terraform.tfstate"
+    bucket     = "encompass-terraform"
+    key        = "prod/terraform.tfstate"
     region     = "us-west-2"
 
     # ddb table to hold tfstate locks.

--- a/terraform/environments/qa/main.tf
+++ b/terraform/environments/qa/main.tf
@@ -3,12 +3,16 @@ variable "db_password" {
   type        = "string"
 }
 
+locals {
+  env_name = "qa"
+}
+
 module "stack" {
   source        = "../../template"
 
-  env_name = "tds-qa"
-  db_id = "tds-qa"
-  instance_name_tag = "tds-qa"
+  env_name = "${local.env_name}"
+  db_id = "encompass-${local.env_name}"
+  instance_name_tag = "encompass-${local.env_name}"
   db_password = "${var.db_password}"
 }
 
@@ -17,8 +21,8 @@ module "stack" {
 # why we can't use the aws_region variable.
 terraform {
   backend "s3" {
-    bucket     = "network-adequacy-terraform"
-    key        = "tds-qa/terraform.tfstate"
+    bucket     = "encompass-terraform"
+    key        = "qa/terraform.tfstate"
     region     = "us-west-2"
 
     # ddb table to hold tfstate locks.

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -99,10 +99,6 @@ resource "aws_security_group" "na_app_sg" {
     protocol        = "-1"
     cidr_blocks     = ["0.0.0.0/0"]
   }
-
-  tags {
-    Name = "na_app_sg"
-  }
 }
 
 # Application load balancer for appserver[s]

--- a/terraform/template/main.tf
+++ b/terraform/template/main.tf
@@ -11,6 +11,9 @@ locals {
 resource "aws_vpc" "main" {
   cidr_block       = "${var.default_vpc_cidr_block}"
   instance_tenancy = "default"
+  lifecycle {
+    prevent_destroy  = true
+  }
 }
 
 # This is the ec2 instance representing the default app server.
@@ -51,7 +54,7 @@ resource "aws_db_instance" "na_db" {
   name                                = "network_adequacy"
   port                                = 5432
   publicly_accessible                 = true
-  snapshot_identifier                 = "encompass-prod-17-1"
+  snapshot_identifier                 = "${var.db_snapshot_id}"
   storage_encrypted                   = false
   storage_type                        = "gp2"
   username                            = "tds"

--- a/terraform/template/variables.tf
+++ b/terraform/template/variables.tf
@@ -4,6 +4,12 @@ variable "app_ami" {
   default     = "ami-9549f5ed" # TDS Base Image from 2018-1-10 in us-west-2
 }
 
+variable "db_snapshot_id" {
+  description = "The snapshot ID to use for initialising the DB server"
+  type        = "string"
+  default     = "encompass-01-24-18"
+}
+
 variable "env_name" {
   description = "The environment identifier e.g. prod"
   type        = "string"


### PR DESCRIPTION
## Description
Creates new QA and Prod environments in us-west-2 so that all resources are in the same region.

Right now the creation of an environment still has two steps which require manual intervention:
* I need to create a better base image because I currently still need to manually shell into an appserver to build the containers and run them.
* I need to add a better security group definition for DB instances, because what is currently in the configuration still requires a manual change.

Still, progress!