### PR TITLE
add semi-placeholder readme for terraform dir (fixes #270)

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,10 @@
+# Infrastructure Management
+## Summary
+This directory contains configuration files for deploying the Encompass application using AWS resources. This project utilises [Terraform](terraform.io) for managing infrastructure resources.
+
+_TODO: extract references to Bayes Impact specific IDs so that the repo contains a configuration that can be used by others._
+## A note on VPCs
+When setting up a new environment, it is recommended that you import your existing main VPC:
+```bash
+terraform import module.stack.aws_vpc.main <your_vpc_arn>
+```


### PR DESCRIPTION
I wanted to add this note that it's worth importing an existing default VPC and figured I might as well start this file. We can write a short guide for this file at some point once we decide on how we want to manage our org-specific variables and update the configuration to have no references to them.