### PR TITLE
Basic deployment automation (fixes #326, fixes #368)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
                 name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
                 command: |
                     echo "testing testing 123" > testing
-                    scp -i brunosp.pem testing ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com:/tmp/
+                    scp testing ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com:/tmp/
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,30 @@ jobs:
                 command: |
                     make frontend-test
 
+    deploy:
+        machine:
+            docker_layer_caching: true
+        steps:
+            - run:
+                name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
+                command: |
+                    echo "testing testing 123" > testing
+                    scp -i brunosp.pem testing ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com:/tmp/
+
 workflows:
     version: 2
     build:
         jobs:
             - build_backend
             - build_frontend
+    build-deploy-qa:
+        jobs:
+#          - build_backend
+#          - build_frontend
+          - deploy:
+#              requires:
+#                - build_backend
+#                - build_frontend
+              filters:
+                branches:
+                  only: deploy-qa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,7 @@ jobs:
             - run:
                 name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
                 command: |
-                    echo "testing testing 123" > testing
-                    scp testing ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com:/tmp/
+                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout ${CIRCLE_COMPARE_URL:(-12)}; docker-compose up -d backend frontend;
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             - run:
                 name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
                 command: |
-                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout ${CIRCLE_COMPARE_URL:(-12)}; docker-compose up -d backend frontend'
+                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
 workflows:
     version: 2
     build:
-        jobs:
+        jobs:  # TODO figure out why `ignore` doesn't work.
             - build_backend:
                 filters:
                     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,23 @@ jobs:
                 command: |
                     make frontend-test
 
-    deploy:
+    deploy-qa:
         machine:
             docker_layer_caching: true
         steps:
             - run:
-                name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
+                name: Perform update over SSH
                 command: |
-                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
+                    ssh ec2-user@$QA_DNS 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
+
+    deploy-demo:
+        machine:
+            docker_layer_caching: true
+        steps:
+            - run:
+                name: Perform update over SSH
+                command: |
+                    ssh ec2-user@$DEMO_DNS 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-demo; git pull origin deploy-demo; docker-compose up -d backend frontend'
 
 workflows:
     version: 2
@@ -72,12 +81,24 @@ workflows:
             - build_frontend
     build-deploy-qa:
         jobs:
-#          - build_backend
-#          - build_frontend
-          - deploy:
-#              requires:
-#                - build_backend
-#                - build_frontend
+          - build_backend
+          - build_frontend
+          - deploy-qa:
+              requires:
+                - build_backend
+                - build_frontend
               filters:
                 branches:
                   only: deploy-qa
+
+    build-deploy-demo:
+        jobs:
+          - build_backend
+          - build_frontend
+          - deploy-demo:
+              requires:
+                - build_backend
+                - build_frontend
+              filters:
+                branches:
+                  only: deploy-demo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,15 +77,22 @@ workflows:
     version: 2
     build:
         jobs:
-            - build_backend
-            - build_frontend
+            - build_backend:
+                filters:
+                    branches:
+                        ignore: /deploy-/
+            - build_frontend:
+                filters:
+                    branches:
+                        ignore: /deploy-/
+
     build-deploy-qa:
         jobs:
-            - build_backend
+            - build_backend:
                 filters:
                     branches:
                         only: deploy-qa
-            - build_frontend
+            - build_frontend:
                 filters:
                     branches:
                         only: deploy-qa
@@ -99,11 +106,11 @@ workflows:
 
     build-deploy-demo:
         jobs:
-            - build_backend
+            - build_backend:
                 filters:
                     branches:
                         only: deploy-demo
-            - build_frontend
+            - build_frontend:
                 filters:
                     branches:
                         only: deploy-demo
@@ -113,4 +120,4 @@ workflows:
                     - build_frontend
                 filters:
                     branches:
-                      only: deploy-demo
+                        only: deploy-demo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             - run:
                 name: Perform update over SSH
                 command: |
-                    ssh ec2-user@$QA_DNS 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
+                    ssh ec2-user@$QA_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
 
     deploy-demo:
         machine:
@@ -71,7 +71,7 @@ jobs:
             - run:
                 name: Perform update over SSH
                 command: |
-                    ssh ec2-user@$DEMO_DNS 'cd tds; docker-compose down; rm .cache/*; git checkout origin deploy-demo; git pull origin deploy-demo; docker-compose up -d backend frontend'
+                    ssh ec2-user@$DEMO_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git checkout origin deploy-demo; git pull origin deploy-demo; docker-compose up -d backend frontend'
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             - run:
                 name: CircleCI2 should have all keys from ui loaded into ssh-agent automatically...
                 command: |
-                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout ${CIRCLE_COMPARE_URL:(-12)}; docker-compose up -d backend frontend;
+                    ssh ec2-user@ec2-54-218-59-142.us-west-2.compute.amazonaws.com 'cd tds; docker-compose down; rm .cache/*; git checkout ${CIRCLE_COMPARE_URL:(-12)}; docker-compose up -d backend frontend'
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             - run:
                 name: Perform update over SSH
                 command: |
-                    ssh ec2-user@$QA_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git checkout origin deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
+                    ssh ec2-user@$QA_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git fetch origin; git checkout deploy-qa; git pull origin deploy-qa; docker-compose up -d backend frontend'
 
     deploy-demo:
         machine:
@@ -71,7 +71,7 @@ jobs:
             - run:
                 name: Perform update over SSH
                 command: |
-                    ssh ec2-user@$DEMO_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git checkout origin deploy-demo; git pull origin deploy-demo; docker-compose up -d backend frontend'
+                    ssh ec2-user@$DEMO_DNS 'cd tds; docker-compose down; sudo rm .cache/*; git fetch origin; git checkout deploy-demo; git pull origin deploy-demo; docker-compose up -d backend frontend'
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,24 +81,36 @@ workflows:
             - build_frontend
     build-deploy-qa:
         jobs:
-          - build_backend
-          - build_frontend
-          - deploy-qa:
-              requires:
-                - build_backend
-                - build_frontend
-              filters:
-                branches:
-                  only: deploy-qa
+            - build_backend
+                filters:
+                    branches:
+                        only: deploy-qa
+            - build_frontend
+                filters:
+                    branches:
+                        only: deploy-qa
+            - deploy-qa:
+                requires:
+                    - build_backend
+                    - build_frontend
+                filters:
+                    branches:
+                        only: deploy-qa
 
     build-deploy-demo:
         jobs:
-          - build_backend
-          - build_frontend
-          - deploy-demo:
-              requires:
-                - build_backend
-                - build_frontend
-              filters:
-                branches:
-                  only: deploy-demo
+            - build_backend
+                filters:
+                    branches:
+                        only: deploy-demo
+            - build_frontend
+                filters:
+                    branches:
+                        only: deploy-demo
+            - deploy-demo:
+                requires:
+                    - build_backend
+                    - build_frontend
+                filters:
+                    branches:
+                      only: deploy-demo

--- a/README.md
+++ b/README.md
@@ -90,3 +90,10 @@ python runners/load_representative_points.py -f data/rhode-island/ri_representat
 
 ### Deploy
 To pull the latest version and re-spin the dockers, simply run `make deploy` in the main directory.
+
+## 4. Remote Deployment
+Sample [Terraform](terraform.io) configuration is provided in the [/terraform directory](/terraform). Further information is available [here](/terraform/README.md).
+
+Sample [CircleCI](circleci.com) configuration is provided in the [/.circleci directory](/.circleci). The default configurations are setup to run all tests and coverage on any branch, and to update remote environments on specific branches. You can modify this configuration to match your own remote environment schema.
+
+To use these CircleCI jobs for deployment, you'll need to set up keys in CircleCI to allow SSH access to your application servers. You'll also need to set the relevant environment variables up containing the DNS names for your application servers.


### PR DESCRIPTION
Ok, super simple one here. When you push to `deploy-qa` or `deploy-demo` branches, circleci will run the tests as usual and then once they are all passed, it will shell into the appserver to clear the cache and restart the containers with the current state of the deploy branch.

It's a naive system but should serve our purposes for now. The outstanding TODO is figure out why that branch ignore thing doesn't work like the documentation suggests it should. It means that right now, pushing to these deploy branches makes cci go through all the tests twice.

To make this work, the shared key for EC2 is added to CCI, and the public DNS for the application servers are also in CCI. We can make a more robust version that will use aws-cli to retrieve correct addresses for when they change, but figured we could get this merged now and I'd make it more clever later.