### PR TITLE
Public limitations for DrivingTime usage (fixes #439)

### DIFF
--- a/backend/app/mocks/responses.py
+++ b/backend/app/mocks/responses.py
@@ -28,9 +28,9 @@ def mock_representative_point(service_area_id=0, rp_id=0):
         'lng': random_lng(),
         'county': county,
         'population': {
-          0.5: random.randint(10, 10000),
-          2.5: random.randint(100, 100000),
-          5: random.randint(1000, 1000000)
+            0.5: random.randint(10, 10000),
+            2.5: random.randint(100, 100000),
+            5: random.randint(1000, 1000000)
         },
         'zip': zip_code,
         'census_block_group': 105,
@@ -50,10 +50,11 @@ def mock_adequacy(rp_id, provider_id):
     }
 
 
-### Helpers
+# Helpers
 def random_coord(seed):
     """Generate a mock lat/lng coordinate."""
     return lambda: seed + random.uniform(-0.03, 0.03)
+
 
 random_lat = random_coord(37.765134)
 random_lng = random_coord(-122.444687)

--- a/backend/app/requests/representative_points.py
+++ b/backend/app/requests/representative_points.py
@@ -52,8 +52,10 @@ def representative_points_request(app, flask_request, engine):
         service_area_ids = request_json['service_area_ids']
     except (json.JSONDecodeError, KeyError):
         raise InvalidFormat(message='Invalid JSON format.')
-    return representative_points.fetch_representative_points(
+    representative_point_response = representative_points.fetch_representative_points(
         service_area_ids,
         census_data=config.get('census_data'),
         engine=engine
     )
+    logger.debug('Returning %d representative points.', len(representative_point_response))
+    return representative_point_response

--- a/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/FilterBar/FilterBar.tsx
@@ -5,8 +5,8 @@ import * as React from 'react'
 import { withStore } from '../../services/store'
 import './FilterBar.css'
 
-export let FilterBar = withStore('method')(({ store }) =>
-  <Paper className='FilterBar' zDepth={1}>
+export let FilterBar = withStore('method', 'allowDrivingTime')(({ store }) => {
+  return <Paper className='FilterBar' zDepth={1}>
     <div className='Filter -FixedWidthBig'>
       <span>Method</span>
       <DropDownMenu
@@ -14,10 +14,10 @@ export let FilterBar = withStore('method')(({ store }) =>
         onChange={(_e, _i, value) => store.set('method')(value)}
         value={store.get('method')}
       >
-        <MenuItem value='driving_time' primaryText='Driving Time' />
+        <MenuItem value='driving_time' primaryText='Driving Time' disabled={!store.get('allowDrivingTime')} />
         <MenuItem value='haversine' primaryText='Haversine Distance' />
       </DropDownMenu>
     </div>
   </Paper>
-)
+})
 FilterBar.displayName = 'FilterBar'

--- a/frontend/src/services/effects.ts
+++ b/frontend/src/services/effects.ts
@@ -12,6 +12,8 @@ import { getPropCaseInsensitive } from '../utils/serializers'
 import { getAdequacies, getRepresentativePoints, isPostGeocodeSuccessResponse, postGeocode } from './api'
 import { Store } from './store'
 
+const { APP_IS_PUBLIC } = process.env
+
 export function withEffects(store: Store) {
   /**
    * Update representative points when serviceAreas change.
@@ -276,6 +278,21 @@ export function withEffects(store: Store) {
         store.set('route')('/datasets')
         store.set('serviceAreas')([])
         store.set('selectedFilterMethod')('All')
+      }
+    })
+
+  /**
+   * Switch to haversine of the app is public and user is adding a dataset.
+   */
+  store
+    .on('route')
+    .subscribe(route => {
+      if (route === '/add-data') {
+        store.set('allowDrivingTime')(!APP_IS_PUBLIC)
+        store.set('method')('haversine')
+      } else if (route === '/datasets') {
+        store.set('allowDrivingTime')(true)
+        store.set('method')('driving_time')
       }
     })
   return store

--- a/frontend/src/services/store.ts
+++ b/frontend/src/services/store.ts
@@ -11,6 +11,8 @@ type Actions = {
 
   adequacies: Adequacies
 
+  allowDrivingTime: boolean
+
   /**
    * Counties selected by the user in the Service Area Drawer.
    *
@@ -137,6 +139,7 @@ type Actions = {
  */
 let store = withEffects(createStore<Actions>({
   adequacies: {},
+  allowDrivingTime: true,
   counties: [],
   error: null,
   success: null,
@@ -144,7 +147,7 @@ let store = withEffects(createStore<Actions>({
   mapCenter: DEFAULT_MAP_CENTER,
   mapCursor: '',
   mapZoom: DEFAULT_MAP_ZOOM,
-  method: 'haversine',
+  method: 'driving_time',
   providerIndex: 0,
   providers: [],
   representativePoints: [],

--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -73,7 +73,8 @@ module.exports = {
       'process.env.MAPBOX_TOKEN': JSON.stringify(process.env.MAPBOX_TOKEN),
       'process.env.SHOULD_SHOW_CSV_UPLOADER': JSON.stringify(process.env.SHOULD_SHOW_CSV_UPLOADER),
       'process.env.NODE_ENV': JSON.stringify('production'),
-      'process.env.TITLE_SUFFIX': JSON.stringify(process.env.TITLE_SUFFIX)
+      'process.env.TITLE_SUFFIX': JSON.stringify(process.env.TITLE_SUFFIX),
+      'process.env.APP_IS_PUBLIC': JSON.stringify(process.env.APP_IS_PUBLIC)
     })
   ]
 }


### PR DESCRIPTION
Limit usage of Driving Time if the app is public facing. This uses a `PUBLIC=true` flag in the .env.