### PR TITLE
Create re-usable caching decorator (fixes #405, fixes #453)

### DIFF
--- a/backend/app/requests/adequacy.py
+++ b/backend/app/requests/adequacy.py
@@ -24,12 +24,11 @@ RESPONSE
 """
 import json
 import logging
-import os
 import random
-import ujson
 
 from backend.app.exceptions.format import InvalidFormat
 from backend.app.mocks.responses import mock_adequacy
+from backend.app.requests.caching import cache
 from backend.config import config
 from backend.lib.calculate import adequacy
 from backend.lib.fetch import representative_points
@@ -38,7 +37,6 @@ from retrying import retry
 
 WAIT_FIXED_MILLISECONDS = 500
 STOP_MAX_ATTEMPT_NUMBER = 2
-DATASET_CACHE_DIRECTORY = config.get('cached_result_directory')
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +54,8 @@ def mock_adequacy_calculation(provider_ids, service_area_ids):
 
 @retry(
     wait_fixed=WAIT_FIXED_MILLISECONDS,
-    stop_max_attempt_number=STOP_MAX_ATTEMPT_NUMBER)
+    stop_max_attempt_number=STOP_MAX_ATTEMPT_NUMBER
+)
 def adequacy_request(app, flask_request, engine):
     """Handle /api/adequacy/ requests."""
     logger.info('Calculating adequacies.')
@@ -88,25 +87,18 @@ def adequacy_request(app, flask_request, engine):
     # Exit early if there is no data.
     if not (provider_locations and service_area_ids):
         return []
-    # If caching is enabled, return cached data.
-    elif dataset_hint and config.get('cache_adequacy_requests'):
-        return _get_cached_adequacy_response(
-            dataset_hint=dataset_hint,
-            measurer_name=measurer_name,
-            service_area_ids=service_area_ids,
-            locations=provider_locations,
-            engine=engine,
-        )
-    else:
-        return adequacy.calculate_adequacies(
-            service_area_ids=service_area_ids,
-            measurer_name=measurer_name,
-            locations=provider_locations,
-            engine=engine,
-        )
+
+    return construct_adequacy_response(
+        dataset_hint=dataset_hint,
+        service_area_ids=service_area_ids,
+        measurer_name=measurer_name,
+        locations=provider_locations,
+        engine=engine,
+    )
 
 
-def _get_cached_adequacy_response(
+@cache(hint_fields=('dataset_hint', 'measurer_name'))
+def construct_adequacy_response(
     dataset_hint,
     measurer_name,
     service_area_ids,
@@ -118,24 +110,9 @@ def _get_cached_adequacy_response(
 
     If no response for the hint is available yet, calculate the adequacy and store for later use.
     """
-    cache_filepath = _convert_dataset_hint_to_cached_filepath(dataset_hint, measurer_name)
-    if os.path.isfile(cache_filepath):
-        with open(cache_filepath, 'r') as f:
-            response = ujson.load(f)
-        logger.debug('Returning cached adequacy results.')
-    else:
-        response = adequacy.calculate_adequacies(
-            engine=engine,
-            service_area_ids=service_area_ids,
-            measurer_name=measurer_name,
-            locations=locations
-        )
-        logger.debug('Caching adequacy results.')
-        with open(cache_filepath, 'w+') as f:
-            json.dump(obj=response, fp=f)
-    return response
-
-
-def _convert_dataset_hint_to_cached_filepath(dataset_hint, measurer_name):
-        dataset_name = 'adequacy_{}_{}.json'.format(dataset_hint, measurer_name)
-        return os.path.join(DATASET_CACHE_DIRECTORY, dataset_name)
+    return adequacy.calculate_adequacies(
+        engine=engine,
+        service_area_ids=service_area_ids,
+        measurer_name=measurer_name,
+        locations=locations
+    )

--- a/backend/app/requests/caching.py
+++ b/backend/app/requests/caching.py
@@ -1,0 +1,83 @@
+"""Methods to cache adequacy and representative points responses."""
+import json
+import logging
+import os
+import six
+
+import ujson
+
+from backend.config import config
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIRECTORY = config.get('cache.directory')
+
+
+def cache(hint_fields):
+    """
+    Decorator function for caching API responses.
+
+    If caching is disabled, responses are not cached.
+    If any of the hint fields are empty or missing, responses are not cached.
+
+    Otherwise, attempt to return previously cached responses, saving the responses
+    whose files do not yet exist.
+    """
+    def wrap(f):
+        @six.wraps(f)
+        def wrapped_f(**kwargs):
+            return _cache(func=f, hint_fields=hint_fields, **kwargs)
+        return wrapped_f
+    return wrap
+
+
+# TODO: Consider separating cache.enabled into cache.read_from_cache
+# and cache.write_to_cache.
+def _cache(func, hint_fields, **kwargs):
+    hint_values = [kwargs.get(field) for field in hint_fields]
+    cache_filepath = _get_cached_filepath(
+        prefix=func.__name__,
+        hint_values=hint_values,
+    )
+    # If caching is disabled or a hint is missing, call the function normally.
+    if not config.get('cache.enabled') or not all(hint_values):
+        response = func(**kwargs)
+    # If the file exists, read and return.
+    elif os.path.isfile(cache_filepath):
+        with open(cache_filepath, 'r') as f:
+            response = ujson.load(f)
+        logger.debug('Returning cached response.')
+    # If the file does not exist, calculate and write to the cache.
+    else:
+        response = func(**kwargs)
+        logger.debug('Storing cached response.')
+        with open(cache_filepath, 'w+') as f:
+            json.dump(obj=response, fp=f)
+
+    return response
+
+
+def _get_cached_filepath(prefix, hint_values):
+    """Return the filepath where a cached response would live for the given inputs."""
+    filename = '{prefix}_{hash_value}.json'.format(
+        prefix=prefix,
+        hash_value=_hash_hint_values(hint_values),
+    )
+    return os.path.join(CACHE_DIRECTORY, filename)
+
+
+def _hash_hint_values(hint_values):
+    """
+    Hash hint values to help identify what cached file to use.
+
+    Attempts to convert unhashable types to hashable equivalents.
+    """
+    # TODO: Handle other unhashable objects.
+    hash_value = 0
+    for value in hint_values:
+        try:
+            hash_value += hash(value)
+        except TypeError:
+            hash_value += (hash(tuple(sorted(value))))
+
+    return hash_value

--- a/backend/app/requests/representative_points.py
+++ b/backend/app/requests/representative_points.py
@@ -29,6 +29,7 @@ RESPONSE
 import json
 import logging
 
+from backend.app.requests.caching import cache
 from backend.config import config
 from backend.lib.fetch import representative_points
 from backend.app.exceptions.format import InvalidFormat
@@ -52,10 +53,19 @@ def representative_points_request(app, flask_request, engine):
         service_area_ids = request_json['service_area_ids']
     except (json.JSONDecodeError, KeyError):
         raise InvalidFormat(message='Invalid JSON format.')
-    representative_point_response = representative_points.fetch_representative_points(
-        service_area_ids,
+    representative_point_response = construct_representative_point_response(
+        service_area_ids=service_area_ids,
         census_data=config.get('census_data'),
         engine=engine
     )
     logger.debug('Returning %d representative points.', len(representative_point_response))
     return representative_point_response
+
+
+@cache(hint_fields=('service_area_ids', 'census_data'))
+def construct_representative_point_response(service_area_ids, census_data, engine):
+    return representative_points.fetch_representative_points(
+        service_area_ids=service_area_ids,
+        census_data=census_data,
+        engine=engine
+    )

--- a/backend/config/config.py
+++ b/backend/config/config.py
@@ -107,8 +107,6 @@ CONFIG = {
     'geocoding': True,
     'address_database': True,
     'geocoder': 'oxcoder',
-    'cache_adequacy_requests': True,
-    'cached_result_directory': '/app/cache/',
     'measurer': {
         'haversine': 'haversine',
         'driving_time': 'osrm'
@@ -136,6 +134,10 @@ CONFIG = {
             'n_adequacy_processors': 255,
             'exit_distance': 5.0 * ONE_MILE_IN_METERS
         }
+    },
+    'cache': {
+        'enabled': True,
+        'directory': '/app/cache/',
     },
     'logging': {
         'version': 1,


### PR DESCRIPTION
Create re-usable caching decorator

Re-run codegen

Abstract caching functionality to decorator level

Use actual census mapping instead of defaulting to {}