### PR TITLE
Add explainer text to dataset selection drawer (fixes #496)

### DIFF
--- a/frontend/src/components/DatasetsDrawer/DatasetsDrawer.css
+++ b/frontend/src/components/DatasetsDrawer/DatasetsDrawer.css
@@ -1,3 +1,7 @@
 .DatasetsDrawer .TilePicker {
   margin: 20px 0;
 }
+
+.DatasetsDrawer a {
+  text-decoration: none;
+}

--- a/frontend/src/components/DatasetsDrawer/DatasetsDrawer.tsx
+++ b/frontend/src/components/DatasetsDrawer/DatasetsDrawer.tsx
@@ -42,7 +42,6 @@ let DatasetTilePicker = TilePicker<Dataset>()
 
 export let DatasetsDrawer = withStore('selectedDataset')(({ store }) =>
   <div className='DatasetsDrawer'>
-    {/*<h2 className='Secondary'>Choose a dataset to explore</h2>*/}
     <p>Welcome to the Encompass analysis tool built by <a href='http://bayesimpact.org'>Beacon Labs</a>. Choose one of the datasets below to begin exploring the accessibility of health care services in different regions of the U.S.</p>
     <p>To send us feedback or ideas for new datasets, you can contact us <a href='mailto:data@bayesimpact.org?subject=Request a dataset'>here</a>.</p>
     <DatasetTilePicker

--- a/frontend/src/components/DatasetsDrawer/DatasetsDrawer.tsx
+++ b/frontend/src/components/DatasetsDrawer/DatasetsDrawer.tsx
@@ -42,7 +42,9 @@ let DatasetTilePicker = TilePicker<Dataset>()
 
 export let DatasetsDrawer = withStore('selectedDataset')(({ store }) =>
   <div className='DatasetsDrawer'>
-    <h2 className='Secondary'>Choose a dataset to explore</h2>
+    {/*<h2 className='Secondary'>Choose a dataset to explore</h2>*/}
+    <p>Welcome to the Encompass analysis tool built by <a href='http://bayesimpact.org'>Beacon Labs</a>. Choose one of the datasets below to begin exploring the accessibility of health care services in different regions of the U.S.</p>
+    <p>To send us feedback or ideas for new datasets, you can contact us <a href='mailto:data@bayesimpact.org?subject=Request a dataset'>here</a>.</p>
     <DatasetTilePicker
       onChange={onChange(store)}
       tiles={tiles}


### PR DESCRIPTION
Added the `text-decoration` for anchors in that div to remove the underlining to match the mockup.

<img width="648" alt="screen shot 2018-03-07 at 4 15 52 pm" src="https://user-images.githubusercontent.com/970955/37125864-3b70e92c-2223-11e8-9fbf-2fd4a9464b54.png">