### PR TITLE
Update headers for tables and CSVs. (Fixes #539)

### DIFF
--- a/frontend/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
+++ b/frontend/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
@@ -102,5 +102,5 @@ function getDataForCensusCategories(serviceAreas: string[] | null, censusCategor
 }
 
 function formatLegend(string: string) {
-  return snakeCase(string.replace('<', 'lt').replace('>', 'gt').replace('-', ' to '))
+  return snakeCase(string.replace('<', 'lt').replace('>', 'gt').replace('-', ' to ').replace('+', ' plus '))
 }

--- a/frontend/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
+++ b/frontend/src/components/DownloadAnalysisLink/DownloadAnalysisLink.tsx
@@ -102,5 +102,5 @@ function getDataForCensusCategories(serviceAreas: string[] | null, censusCategor
 }
 
 function formatLegend(string: string) {
-  return snakeCase(string.replace('<', 'lt').replace('>', 'gt').replace('-', ' to ').replace('+', ' plus '))
+  return snakeCase(string.replace('<', 'lt').replace('>', 'gt').replace('-', ' to ').replace('+', ' plus ').replace('Years', 'yrs'))
 }

--- a/frontend/src/components/MapLegend/MapLegend.tsx
+++ b/frontend/src/components/MapLegend/MapLegend.tsx
@@ -30,18 +30,18 @@ export function getLegend(method: Method, standard: AdequacyMode) {
   switch (method) {
     case 'straight_line':
       switch (standard) {
-        case AdequacyMode.ADEQUATE_0: return '< 10 miles'
-        case AdequacyMode.ADEQUATE_1: return '< 20 miles'
-        case AdequacyMode.ADEQUATE_2: return '< 30 miles'
-        case AdequacyMode.INADEQUATE: return '> 30 miles'
+        case AdequacyMode.ADEQUATE_0: return '0 to 10 miles'
+        case AdequacyMode.ADEQUATE_1: return '10 to 20 miles'
+        case AdequacyMode.ADEQUATE_2: return '20 to 30 miles'
+        case AdequacyMode.INADEQUATE: return 'over 30 miles'
       }
       break
     case 'driving_time':
       switch (standard) {
-        case AdequacyMode.ADEQUATE_0: return '< 30 min'
-        case AdequacyMode.ADEQUATE_1: return '< 45 min'
-        case AdequacyMode.ADEQUATE_2: return '< 60 min'
-        case AdequacyMode.INADEQUATE: return '> 60 min'
+        case AdequacyMode.ADEQUATE_0: return '0 to 30 min'
+        case AdequacyMode.ADEQUATE_1: return '30 to 45 min'
+        case AdequacyMode.ADEQUATE_2: return '45 to 60 min'
+        case AdequacyMode.INADEQUATE: return 'over 60 min'
       }
       break
   }

--- a/frontend/src/components/MapLegend/MapLegend.tsx
+++ b/frontend/src/components/MapLegend/MapLegend.tsx
@@ -30,18 +30,18 @@ export function getLegend(method: Method, standard: AdequacyMode) {
   switch (method) {
     case 'straight_line':
       switch (standard) {
-        case AdequacyMode.ADEQUATE_0: return '0 to 10 miles'
-        case AdequacyMode.ADEQUATE_1: return '10 to 20 miles'
-        case AdequacyMode.ADEQUATE_2: return '20 to 30 miles'
-        case AdequacyMode.INADEQUATE: return 'over 30 miles'
+        case AdequacyMode.ADEQUATE_0: return '0-10 mi'
+        case AdequacyMode.ADEQUATE_1: return '10-20 mi'
+        case AdequacyMode.ADEQUATE_2: return '20-30 mi'
+        case AdequacyMode.INADEQUATE: return '30+ mi'
       }
       break
     case 'driving_time':
       switch (standard) {
-        case AdequacyMode.ADEQUATE_0: return '0 to 30 min'
-        case AdequacyMode.ADEQUATE_1: return '30 to 45 min'
-        case AdequacyMode.ADEQUATE_2: return '45 to 60 min'
-        case AdequacyMode.INADEQUATE: return 'over 60 min'
+        case AdequacyMode.ADEQUATE_0: return '0-30 min'
+        case AdequacyMode.ADEQUATE_1: return '30-45 min'
+        case AdequacyMode.ADEQUATE_2: return '45-60 min'
+        case AdequacyMode.INADEQUATE: return '60+ min'
       }
       break
   }

--- a/frontend/src/constants/census.ts
+++ b/frontend/src/constants/census.ts
@@ -11,12 +11,12 @@ export const CENSUS_MAPPING_ERROR = 'No Census Mapping Detected'
 
 export const CENSUS_MAPPING: censusMapping = {
   age: [
-    '0-18 Years',
-    '19-25 Years',
-    '26-34 Years',
-    '35-54 Years',
-    '55-64 Years',
-    '65+ Years'
+    '0-18 Yrs',
+    '19-25 Yrs',
+    '26-34 Yrs',
+    '35-54 Yrs',
+    '55-64 Yrs',
+    '65+ Yrs'
   ],
   sex: ['Male', 'Female'],
   race: [

--- a/frontend/src/constants/census.ts
+++ b/frontend/src/constants/census.ts
@@ -11,12 +11,12 @@ export const CENSUS_MAPPING_ERROR = 'No Census Mapping Detected'
 
 export const CENSUS_MAPPING: censusMapping = {
   age: [
-    '0-18 Years',
-    '19-25 Years',
-    '26-34 Years',
-    '35-54 Years',
-    '55-64 Years',
-    '65+ Years'
+    '0-18 years',
+    '19-25 years',
+    '26-34 years',
+    '35-54 years',
+    '55-64 years',
+    '65+ years'
   ],
   sex: ['Male', 'Female'],
   race: [

--- a/frontend/src/constants/census.ts
+++ b/frontend/src/constants/census.ts
@@ -11,12 +11,12 @@ export const CENSUS_MAPPING_ERROR = 'No Census Mapping Detected'
 
 export const CENSUS_MAPPING: censusMapping = {
   age: [
-    '0-18 Yrs',
-    '19-25 Yrs',
-    '26-34 Yrs',
-    '35-54 Yrs',
-    '55-64 Yrs',
-    '65+ Yrs'
+    '0-18 Years',
+    '19-25 Years',
+    '26-34 Years',
+    '35-54 Years',
+    '55-64 Years',
+    '65+ Years'
   ],
   sex: ['Male', 'Female'],
   race: [

--- a/shared/census_mapping.json
+++ b/shared/census_mapping.json
@@ -2,27 +2,27 @@
   "age": {
     "aggregated_ages.zero_to_eighteen_percent": {
       "joined_column_name": "zero_to_eighteen",
-      "human_readable_name": "0-18 Years"
+      "human_readable_name": "0-18 Yrs"
     },
     "aggregated_ages.nineteen_to_twenty_five_percent": {
       "joined_column_name": "nineteen_to_twenty_five",
-      "human_readable_name": "19-25 Years"
+      "human_readable_name": "19-25 Yrs"
     },
     "aggregated_ages.twenty_six_to_thirty_four_percent": {
       "joined_column_name": "twenty_six_to_thirty_four",
-      "human_readable_name": "26-34 Years"
+      "human_readable_name": "26-34 Yrs"
     },
     "aggregated_ages.thirty_five_to_fifty_four_percent": {
       "joined_column_name": "thirty_five_to_fifty_four",
-      "human_readable_name": "35-54 Years"
+      "human_readable_name": "35-54 Yrs"
     },
     "aggregated_ages.fifty_five_to_sixty_four_percent": {
       "joined_column_name": "fifty_five_to_sixty_four",
-      "human_readable_name": "55-64 Years"
+      "human_readable_name": "55-64 Yrs"
     },
     "aggregated_ages.sixty_five_plus_percent": {
       "joined_column_name": "sixty_five_plus",
-      "human_readable_name": "65+ Years"
+      "human_readable_name": "65+ Yrs"
     }
   },
   "sex": {

--- a/shared/census_mapping.json
+++ b/shared/census_mapping.json
@@ -2,27 +2,27 @@
   "age": {
     "aggregated_ages.zero_to_eighteen_percent": {
       "joined_column_name": "zero_to_eighteen",
-      "human_readable_name": "0-18 Years"
+      "human_readable_name": "0-18 years"
     },
     "aggregated_ages.nineteen_to_twenty_five_percent": {
       "joined_column_name": "nineteen_to_twenty_five",
-      "human_readable_name": "19-25 Years"
+      "human_readable_name": "19-25 years"
     },
     "aggregated_ages.twenty_six_to_thirty_four_percent": {
       "joined_column_name": "twenty_six_to_thirty_four",
-      "human_readable_name": "26-34 Years"
+      "human_readable_name": "26-34 years"
     },
     "aggregated_ages.thirty_five_to_fifty_four_percent": {
       "joined_column_name": "thirty_five_to_fifty_four",
-      "human_readable_name": "35-54 Years"
+      "human_readable_name": "35-54 years"
     },
     "aggregated_ages.fifty_five_to_sixty_four_percent": {
       "joined_column_name": "fifty_five_to_sixty_four",
-      "human_readable_name": "55-64 Years"
+      "human_readable_name": "55-64 years"
     },
     "aggregated_ages.sixty_five_plus_percent": {
       "joined_column_name": "sixty_five_plus",
-      "human_readable_name": "65+ Years"
+      "human_readable_name": "65+ years"
     }
   },
   "sex": {

--- a/shared/census_mapping.json
+++ b/shared/census_mapping.json
@@ -2,27 +2,27 @@
   "age": {
     "aggregated_ages.zero_to_eighteen_percent": {
       "joined_column_name": "zero_to_eighteen",
-      "human_readable_name": "0-18 Yrs"
+      "human_readable_name": "0-18 Years"
     },
     "aggregated_ages.nineteen_to_twenty_five_percent": {
       "joined_column_name": "nineteen_to_twenty_five",
-      "human_readable_name": "19-25 Yrs"
+      "human_readable_name": "19-25 Years"
     },
     "aggregated_ages.twenty_six_to_thirty_four_percent": {
       "joined_column_name": "twenty_six_to_thirty_four",
-      "human_readable_name": "26-34 Yrs"
+      "human_readable_name": "26-34 Years"
     },
     "aggregated_ages.thirty_five_to_fifty_four_percent": {
       "joined_column_name": "thirty_five_to_fifty_four",
-      "human_readable_name": "35-54 Yrs"
+      "human_readable_name": "35-54 Years"
     },
     "aggregated_ages.fifty_five_to_sixty_four_percent": {
       "joined_column_name": "fifty_five_to_sixty_four",
-      "human_readable_name": "55-64 Yrs"
+      "human_readable_name": "55-64 Years"
     },
     "aggregated_ages.sixty_five_plus_percent": {
       "joined_column_name": "sixty_five_plus",
-      "human_readable_name": "65+ Yrs"
+      "human_readable_name": "65+ Years"
     }
   },
   "sex": {


### PR DESCRIPTION
New headers in CSV: ```county,total_0_to_10_miles,total_10_to_20_miles,total_20_to_30_miles,total_over_30_miles,min_straight_line,avg_straight_line,max_straight_line,age_0_to_18_yrs_0_to_10_miles,age_0_to_18_yrs_10_to_20_miles,age_0_to_18_yrs_20_to_30_miles,age_0_to_18_yrs_over_30_miles,age_19_to_25_yrs_0_to_10_miles,age_19_to_25_yrs_10_to_20_miles,age_19_to_25_yrs_20_to_30_miles,age_19_to_25_yrs_over_30_miles,age_26_to_34_yrs_0_to_10_miles,age_26_to_34_yrs_10_to_20_miles,age_26_to_34_yrs_20_to_30_miles,age_26_to_34_yrs_over_30_miles,age_35_to_54_yrs_0_to_10_miles,age_35_to_54_yrs_10_to_20_miles,age_35_to_54_yrs_20_to_30_miles,age_35_to_54_yrs_over_30_miles,age_55_to_64_yrs_0_to_10_miles,age_55_to_64_yrs_10_to_20_miles,age_55_to_64_yrs_20_to_30_miles,age_55_to_64_yrs_over_30_miles,age_65_plus_yrs_0_to_10_miles,age_65_plus_yrs_10_to_20_miles,age_65_plus_yrs_20_to_30_miles,age_65_plus_yrs_over_30_miles,income_lt_15_k_0_to_10_miles,income_lt_15_k_10_to_20_miles,income_lt_15_k_20_to_30_miles,income_lt_15_k_over_30_miles,income_15_k_to_50_k_0_to_10_miles,income_15_k_to_50_k_10_to_20_miles,income_15_k_to_50_k_20_to_30_miles,income_15_k_to_50_k_over_30_miles,income_50_k_to_100_k_0_to_10_miles,income_50_k_to_100_k_10_to_20_miles,income_50_k_to_100_k_20_to_30_miles,income_50_k_to_100_k_over_30_miles,income_100_k_to_150_k_0_to_10_miles,income_100_k_to_150_k_10_to_20_miles,income_100_k_to_150_k_20_to_30_miles,income_100_k_to_150_k_over_30_miles,income_150_k_to_200_k_0_to_10_miles,income_150_k_to_200_k_10_to_20_miles,income_150_k_to_200_k_20_to_30_miles,income_150_k_to_200_k_over_30_miles,income_gt_200_k_0_to_10_miles,income_gt_200_k_10_to_20_miles,income_gt_200_k_20_to_30_miles,income_gt_200_k_over_30_miles,insurance_private_health_insurance_0_to_10_miles,insurance_private_health_insurance_10_to_20_miles,insurance_private_health_insurance_20_to_30_miles,insurance_private_health_insurance_over_30_miles,insurance_public_health_insurance_0_to_10_miles,insurance_public_health_insurance_10_to_20_miles,insurance_public_health_insurance_20_to_30_miles,insurance_public_health_insurance_over_30_miles,insurance_no_health_insurance_0_to_10_miles,insurance_no_health_insurance_10_to_20_miles,insurance_no_health_insurance_20_to_30_miles,insurance_no_health_insurance_over_30_miles,race_hispanic_or_latino_any_race_0_to_10_miles,race_hispanic_or_latino_any_race_10_to_20_miles,race_hispanic_or_latino_any_race_20_to_30_miles,race_hispanic_or_latino_any_race_over_30_miles,race_white_0_to_10_miles,race_white_10_to_20_miles,race_white_20_to_30_miles,race_white_over_30_miles,race_black_0_to_10_miles,race_black_10_to_20_miles,race_black_20_to_30_miles,race_black_over_30_miles,race_american_indian_alaska_native_0_to_10_miles,race_american_indian_alaska_native_10_to_20_miles,race_american_indian_alaska_native_20_to_30_miles,race_american_indian_alaska_native_over_30_miles,race_asian_0_to_10_miles,race_asian_10_to_20_miles,race_asian_20_to_30_miles,race_asian_over_30_miles,race_native_hawaiian_other_pacific_islander_0_to_10_miles,race_native_hawaiian_other_pacific_islander_10_to_20_miles,race_native_hawaiian_other_pacific_islander_20_to_30_miles,race_native_hawaiian_other_pacific_islander_over_30_miles,race_multiracial_or_other_0_to_10_miles,race_multiracial_or_other_10_to_20_miles,race_multiracial_or_other_20_to_30_miles,race_multiracial_or_other_over_30_miles,sex_male_0_to_10_miles,sex_male_10_to_20_miles,sex_male_20_to_30_miles,sex_male_over_30_miles,sex_female_0_to_10_miles,sex_female_10_to_20_miles,sex_female_20_to_30_miles,sex_female_over_30_miles```

This also updates the headers (and legend labels) on the page itself:

<img width="549" alt="screen shot 2018-03-26 at 10 41 42 am" src="https://user-images.githubusercontent.com/970955/37922924-c3a7d576-30e2-11e8-9df6-d05e1ce42eba.png">
<img width="139" alt="screen shot 2018-03-26 at 10 42 03 am" src="https://user-images.githubusercontent.com/970955/37922925-c3d2365e-30e2-11e8-8fbc-6302cc6c8fe4.png">
