### PR TITLE
Add build_cache function

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,19 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
       "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ=="
     },
+    "@types/node": {
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ=="
+    },
+    "@types/node-fetch": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.8.tgz",
+      "integrity": "sha512-O8DUwXf7KUBu036HAbF5RKRaA1vvE0BsaPfAnC9YD7Xy4eNoJmNIdEjBIEEHAVszozRgH4m9JnVCsueSKiKXMA==",
+      "requires": {
+        "@types/node": "9.6.6"
+      }
+    },
     "@types/rx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
@@ -1032,14 +1045,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -2430,11 +2435,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
     "ieee754": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
@@ -2616,11 +2616,6 @@
         "isobject": "3.0.1"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2644,7 +2639,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -2950,13 +2944,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-libs-browser": {
       "version": "2.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "author": "Boris Cherny <boris@performancejs.com>",
   "license": "Apache-2.0",
   "scripts": {
+    "build-cache": "ts-node scripts/buildCache.ts",
     "build": "webpack",
     "build:prod": "webpack --config webpack.config.prod.js",
     "codegen": "ts-node scripts/codegen.ts",
@@ -53,6 +54,7 @@
     "fetch-mock": "^5.13.1",
     "fork-ts-checker-webpack-plugin": "^0.4.0",
     "html-webpack-plugin": "^3.0.4",
+    "isomorphic-fetch": "^2.2.1",
     "jest": "^21.2.1",
     "jest-css-modules": "^1.1.0",
     "jest-fetch-mock": "^1.3.3",
@@ -64,6 +66,7 @@
     "postcss-import": "^11.1.0",
     "postcss-loader": "^2.1.1",
     "prettier": "^1.9.2",
+    "promise-seq": "^4.0.1",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "rmfr": "^1.0.3",

--- a/frontend/scripts/buildCache.ts
+++ b/frontend/scripts/buildCache.ts
@@ -1,0 +1,59 @@
+/**
+ * Codegens API typings
+ */
+import Axios from 'axios'
+import 'isomorphic-fetch'
+import { seq } from 'promise-seq'
+import { CONFIG } from '../src/config/config'
+import { DATASETS } from '../src/constants/datasets'
+import { Method } from '../src/constants/datatypes'
+import {
+  getAdequacies, getCensusData, getRepresentativePoints
+} from '../src/services/api'
+import { safeDatasetHint } from '../src/utils/formatters'
+const METHODS: Method[] = ['driving_time', 'straight_line']
+
+main()
+
+async function main() {
+
+  console.info('Running cache build...')
+  if (!CONFIG.cache.enabled) {
+    throw Error('Caching is not activated in the config file.')
+  }
+  await testAPIAccess()
+  console.info('[Step 1] Get representative points and census')
+  await cacheRPCensus()
+
+  console.info('[Step 2] Cache Adequacies')
+  await cacheAdequacies()
+}
+
+async function testAPIAccess() {
+  let r = await Axios.get('http://localhost:8080/api/available-service-areas/')
+  if (r.status !== 200) {
+    throw Error('GETting http://localhost:8080/api/available-service-areas/. Is the server running?')
+  }
+}
+
+function cacheRPCensus() {
+  return seq(...DATASETS.map(_ => async () => {
+    console.log('  Getting RPs and Census for ' + safeDatasetHint(_))
+    await getRepresentativePoints({ service_area_ids: _.serviceAreaIds })
+    await getCensusData({ service_area_ids: _.serviceAreaIds })
+  }))
+}
+
+function cacheAdequacies() {
+  return seq(...DATASETS.map(dataset => async () =>
+    seq(...METHODS.map(method => async () => {
+      console.log('  Getting Adequacy for ' + safeDatasetHint(dataset) + ' for ' + method)
+      return getAdequacies({
+        method,
+        providers: dataset.providers.map((_, n) => ({ latitude: _.lat, longitude: _.lng, id: n })),
+        service_area_ids: dataset.serviceAreaIds,
+        dataset_hint: safeDatasetHint(dataset)
+      })
+    }))
+  ))
+}

--- a/frontend/src/constants/datatypes.ts
+++ b/frontend/src/constants/datatypes.ts
@@ -41,6 +41,9 @@ export type Config = {
   analysis: {
     [key: string]: boolean
   }
+  cache: {
+    [key: string]: string | boolean
+  }
   dataset: {
     [key: string]: boolean
   }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,10 +16,9 @@ let request = (method: 'GET' | 'POST') =>
     <T>(body: object) => {
 
       // Set JSON headers
-      let headers = new Headers
+      let headers = new Headers()
       headers.set('Accept', 'application/json, text/plain, */*')
       headers.set('Content-Type', 'application/json')
-
       // Send request
       return fetch(API_ROOT + url, {
         body: JSON.stringify(body),

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,3 +1,4 @@
+import { Dataset } from '../constants/datatypes'
 import { State } from '../constants/states'
 import { serializeServiceArea } from './serializers'
 import { capitalizeWords, snakeCase } from './string'
@@ -141,4 +142,11 @@ export function parseSerializedServiceArea(serializedServiceArea: string) {
     state: serializedServiceArea.slice(0, 2) as State,
     zip: serializedServiceArea.slice(-5)
   }
+}
+
+export function safeDatasetHint(dataset: Dataset | null) {
+  if (dataset === null) {
+    return ''
+  }
+  return dataset['hint']
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7006,6 +7006,10 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
+promise-seq@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/promise-seq/-/promise-seq-4.0.1.tgz#aca6b6e3fa65b3e7f650304c16b0dc0c24c224e2"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
This PR is an attempt at re-building the cache in the backend for the rp, census and adequacy endpoint. We mimick the requests that the frontend sends when a user clicks on a dataset to force the backend to prepare the response and build the cache if it did not exist.

At the moment, the backend, and esp the OSRM server for routing, does not really like the 1,000 concurrent requests that it is getting and I would like a way to go through the datasets one by one @bcherny. Thoughts?