### PR TITLE
Use circles for adequacy legend fixes #690

### DIFF
--- a/frontend/src/components/MapLegend/MapLegend.css
+++ b/frontend/src/components/MapLegend/MapLegend.css
@@ -17,4 +17,8 @@
   position: relative;
     bottom: -3px;
   width: 16px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 5px;
+  opacity: 0.8;
 }

--- a/frontend/src/components/MapLegend/MapLegend.css
+++ b/frontend/src/components/MapLegend/MapLegend.css
@@ -18,7 +18,5 @@
     bottom: -3px;
   width: 16px;
   border-radius: 50%;
-  display: inline-block;
-  margin-right: 5px;
   opacity: 0.8;
 }


### PR DESCRIPTION
Not really possible to have a legend for size because it changes exponentially with zoom
![image](https://user-images.githubusercontent.com/11825994/39605991-f0842090-4ee7-11e8-90ff-04e2fd56d501.png)
