### PR TITLE
Make github icon white

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import AppBar from 'material-ui/AppBar'
 import FlatButton from 'material-ui/FlatButton'
 import IconButton from 'material-ui/IconButton'
+import { white } from 'material-ui/styles/colors'
 import GithubIcon from 'mui-icons/cmdi/github'
 import * as React from 'react'
 import { CONFIG } from '../../config/config'
@@ -38,7 +39,7 @@ export let Header = withStore('modal')(({ store }) =>
           tooltip='Go to this project on GitHub'
           tooltipPosition='bottom-left'
           touch={true}
-        > <GithubIcon /></IconButton>
+        > <GithubIcon color={white} /></IconButton>
       </div>
     }
     showMenuIconButton={false}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11825994/39607708-59ce89b0-4ef1-11e8-8fd4-9000fa03c1a9.png)

confirmed that they do in fact have a light version on their logo download page