### PR TITLE
Display loading gif on selected state change fixes #751

### DIFF
--- a/frontend/src/components/AnalyticsDrawer/CensusAnalytics.tsx
+++ b/frontend/src/components/AnalyticsDrawer/CensusAnalytics.tsx
@@ -17,7 +17,6 @@ export let CensusAnalytics = withStore(
   'selectedServiceAreas',
   'serviceAreas'
 )(({ store }) => {
-
   let selectedServiceAreas = store.get('selectedServiceAreas') ? store.get('selectedServiceAreas')! : store.get('serviceAreas')
   let selectedCensusCategory = store.get('selectedCensusCategory')
   let populationByAdequacy = summaryStatisticsByServiceArea(selectedServiceAreas, store)

--- a/frontend/src/components/AnalyticsDrawer/CensusAnalytics.tsx
+++ b/frontend/src/components/AnalyticsDrawer/CensusAnalytics.tsx
@@ -17,6 +17,7 @@ export let CensusAnalytics = withStore(
   'selectedServiceAreas',
   'serviceAreas'
 )(({ store }) => {
+
   let selectedServiceAreas = store.get('selectedServiceAreas') ? store.get('selectedServiceAreas')! : store.get('serviceAreas')
   let selectedCensusCategory = store.get('selectedCensusCategory')
   let populationByAdequacy = summaryStatisticsByServiceArea(selectedServiceAreas, store)

--- a/frontend/src/services/effects.ts
+++ b/frontend/src/services/effects.ts
@@ -256,6 +256,7 @@ export function withEffects(store: Store) {
   store
     .on('selectedState')
     .subscribe(() => {
+      store.set('adequacies')({})
       store.set('counties')([])
       store.set('selectedCounties')(null)
       store.set('useCustomCountyUpload')(null)


### PR DESCRIPTION
Note, there was a downstream effect that was setting adequacies to null, but appeared to be waiting for something else before doing it. This sets adequacies to null immediately to get the loading gif to show until new adequacies are determined
![loadingwhenstateloading](https://user-images.githubusercontent.com/11825994/39642825-bb8940fa-4f87-11e8-830b-a110c96f811d.gif)
