### PR TITLE
Change capitalization in Circle-CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Encompass
 
-[![Build Status][build]](https://circleci.com/gh/beaconlabs/encompass) [![apache2]](https://www.apache.org/licenses/LICENSE-2.0)
+[![Build Status][build]](https://circleci.com/gh/BeaconLabs/encompass) [![apache2]](https://www.apache.org/licenses/LICENSE-2.0)
 
-[build]: https://img.shields.io/circleci/project/beaconlabs/encompass.svg?branch=master&style=flat-square
+[build]: https://img.shields.io/circleci/project/BeaconLabs/encompass.svg?branch=master&style=flat-square
 [apache2]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/beaconlabs/encompass.svg?columns=all)](http://waffle.io/beaconlabs/encompass)
 


### PR DESCRIPTION
The purpose of this PR is to get the build status badge to say `passing` -- it currently says `project not found`.