### PR TITLE
Update tooltip to Unknown for islands fixes #790

### DIFF
--- a/backend/models/time.py
+++ b/backend/models/time.py
@@ -4,6 +4,7 @@ import os
 import requests
 import logging
 
+from backend.config import config
 from backend.lib.utils import iterators
 from backend.models import distance
 from backend.models.base import Measurer
@@ -19,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 # TODO: Determine a more intelligent way for converting distance to time.
 TIME_TO_DISTANCE_HOURS_TO_METERS = 104607.0  # 65 miles per hour in meters per hour.
-ABSURDLY_LARGE_TIME_IN_MINUTES = 10**42  # Placeholder value when no nearby providers are found.
+
+ABSURDLY_LARGE_TIME_IN_MINUTES = config.get('absurdly_large_placeholder_time') # Placeholder value when no nearby providers are found.
 
 
 def _retry_if_result_none(result):

--- a/frontend/src/constants/datatypes.ts
+++ b/frontend/src/constants/datatypes.ts
@@ -34,6 +34,7 @@ export type Config = {
   is_walking_available: boolean
   limit_upload_file_size: boolean
   show_about_dialog_on_start: boolean
+  absurdly_large_placeholder_time: Number
   title_suffix: string
   api: {
     [key: string]: string | boolean

--- a/frontend/src/services/store.ts
+++ b/frontend/src/services/store.ts
@@ -1,7 +1,7 @@
 import { FeatureCollection, GeometryObject } from 'geojson'
 import { Map } from 'mapbox-gl'
 import { isMobile } from 'react-device-detect'
-import { connect, createStore, Store as BabyduxStore, withLogger } from 'undux'
+import { connect, createStore, Store as BabyduxStore } from 'undux'
 import { CONFIG } from '../config/config'
 import { CENSUS_MAPPING, CENSUS_MAPPING_ERROR } from '../constants/census'
 import { Adequacies, CountyType, Dataset, FilterMethod, Format, GeocodedProvider, GeoJSONEventData, Method, ModalName, Provider, RepresentativePoint, Route } from '../constants/datatypes'
@@ -156,7 +156,7 @@ type Actions = {
 /**
  * Note: Do not export this. Use `withStore` or effects (see effects.ts) instead.
  */
-let store = withLogger(withEffects(createStore<Actions>({
+let store = withEffects(createStore<Actions>({
   adequacies: {},
   allowDrivingTime: true,
   counties: [],
@@ -190,7 +190,7 @@ let store = withLogger(withEffects(createStore<Actions>({
   uploadedProvidersFilename: null,
   uploadedServiceAreasFilename: null,
   pointFeatureCollections: null
-})))
+}))
 
 export let withStore = connect(store)
 

--- a/frontend/src/services/store.ts
+++ b/frontend/src/services/store.ts
@@ -1,7 +1,7 @@
 import { FeatureCollection, GeometryObject } from 'geojson'
 import { Map } from 'mapbox-gl'
 import { isMobile } from 'react-device-detect'
-import { connect, createStore, Store as BabyduxStore } from 'undux'
+import { connect, createStore, Store as BabyduxStore, withLogger } from 'undux'
 import { CONFIG } from '../config/config'
 import { CENSUS_MAPPING, CENSUS_MAPPING_ERROR } from '../constants/census'
 import { Adequacies, CountyType, Dataset, FilterMethod, Format, GeocodedProvider, GeoJSONEventData, Method, ModalName, Provider, RepresentativePoint, Route } from '../constants/datatypes'
@@ -156,7 +156,7 @@ type Actions = {
 /**
  * Note: Do not export this. Use `withStore` or effects (see effects.ts) instead.
  */
-let store = withEffects(createStore<Actions>({
+let store = withLogger(withEffects(createStore<Actions>({
   adequacies: {},
   allowDrivingTime: true,
   counties: [],
@@ -190,7 +190,7 @@ let store = withEffects(createStore<Actions>({
   uploadedProvidersFilename: null,
   uploadedServiceAreasFilename: null,
   pointFeatureCollections: null
-}))
+})))
 
 export let withStore = connect(store)
 

--- a/frontend/src/utils/geojson.ts
+++ b/frontend/src/utils/geojson.ts
@@ -1,5 +1,6 @@
 import * as extent from 'esri-extent'
 import { pickBy } from 'lodash'
+import { CONFIG } from '../config/config'
 import { CENSUS_MAPPING } from '../constants/census'
 import { Adequacies, GeocodedProvider, Method, RepresentativePoint } from '../constants/datatypes'
 import { formatGMapsCoordinates, formatGMapsDirection } from '../utils/formatters'
@@ -82,6 +83,9 @@ function toClosestProviderToString(adequacies: Adequacies, method: Method, point
     case 'straight_line':
       return Math.round((adequacies[pointId].toClosestProvider / 1609.34)).toString() + ' miles'
     case 'driving_time':
+      if (adequacies[pointId].toClosestProvider === CONFIG.absurdly_large_placeholder_time) {
+        return 'Unknown'
+      }
       return Math.round(adequacies[pointId].toClosestProvider).toString() + ' minutes'
   }
 }

--- a/shared/config.json
+++ b/shared/config.json
@@ -1,6 +1,7 @@
 {
     "enable_geocoding": true,
     "is_census_data_available": true,
+    "absurdly_large_placeholder_time": 1e42,
     "_backend": "Configuration used by the backend.",
     "use_address_cache": true,
     "geocoder": "geocodio",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11825994/39945581-ecc0077e-551f-11e8-8388-abe6a01c8eee.png)

still shows google maps link, but google doesn't know how to get between them either. I can update that to not show or something.

The weird thing is that we know which provider is the closest, we just don't know how to get there. 